### PR TITLE
Fix package json and asmdefs

### DIFF
--- a/Packages/dev.sworks.blendmaestro/Editor/dev.sworks.blendmaestro.Editor.asmdef
+++ b/Packages/dev.sworks.blendmaestro/Editor/dev.sworks.blendmaestro.Editor.asmdef
@@ -2,10 +2,6 @@
     "name": "dev.sworks.blendmaestro.Editor",
     "rootNamespace": "",
     "references": [
-        "VRC.SDK3A",
-        "VRC.SDK3A.Editor",
-        "VRC.SDKBase",
-        "VRC.SDKBase.Editor",
         "dev.sworks.blendmaestro"
     ],
     "includePlatforms": [
@@ -13,7 +9,7 @@
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
+    "overrideReferences": true,
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],

--- a/Packages/dev.sworks.blendmaestro/Runtime/dev.sworks.blendmaestro.asmdef
+++ b/Packages/dev.sworks.blendmaestro/Runtime/dev.sworks.blendmaestro.asmdef
@@ -1,14 +1,11 @@
 {
     "name": "dev.sworks.blendmaestro",
     "rootNamespace": "",
-    "references": [
-        "VRC.SDK3A",
-        "VRC.SDKBase"
-    ],
+    "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
+    "overrideReferences": true,
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],

--- a/Packages/dev.sworks.blendmaestro/package.json
+++ b/Packages/dev.sworks.blendmaestro/package.json
@@ -3,16 +3,11 @@
   "displayName": "BlendMaestro",
   "version": "1.1.5",
   "description": "Non Destructive Blendshape Merge Tool",
-  "gitDependencies": {},
-  "vpmDependencies": {
-    "com.vrchat.avatars": "3.6.1"
-  },
   "author": {
     "name": "sinkunvv",
     "email": "",
     "url": "https://twitter.com/sinkunvv"
   },
   "legacyFolders": {},
-  "legacyFiles": {},
-  "localPath": "D:\\workspace\\BlendMaestro\\Packages\\dev.sworks.blendmaestro"
+  "legacyFiles": {}
 }

--- a/Packages/dev.sworks.blendmaestro/package.json
+++ b/Packages/dev.sworks.blendmaestro/package.json
@@ -8,6 +8,7 @@
     "email": "",
     "url": "https://twitter.com/sinkunvv"
   },
-  "legacyFolders": {},
-  "legacyFiles": {}
+  "legacyFolders": {
+    "Assets/S.WORKS/BlendMaestro": "b07e337758056b44baa518786055d975"
+  }
 }


### PR DESCRIPTION
この Pull Request では package.json の設定と .asmdef の設定をより最適化しました。

これらの設定はおそらく VRChat Package Resolver 同梱の Package Maker を使用したのだと思われますが、Package Maker の作成する manifest がもともとベストではなかったため、それらの修正になります。

- 各 .asmdef が余計なアセンブリを参照している問題を修正しました。 (3aac10aa9c17e2fddbfa914e5577a7ce4adc9902)  
  これにより、BlendMaestroとVRCSDKを同時に導入したり、更新したときの Unity での処理が最適化されます。
- VRCSDK Avatars 3.6.1 以外の環境にインストールできない問題を修正しました。 (594319f0db8615567fd7ccc7a3f8d61d5f8e2057)  
  私が fork & pull request をする理由となったもとの問題になります。(友達が問題を踏んだため送らせていただきました。 https://misskey.niri.la/notes/a6tbmle9t1)  
  もともと VRCSDK への依存がなかったようですが、 3aac10aa9c17e2fddbfa914e5577a7ce4adc9902 にて VRCSDK への依存が名実ともになくなったため、 VRCSDK の依存関係を消しました  
  これによりVRCSDKのない環境でもVCC / ALCOM 等で導入可能になり、また VRCSDK Worlds 環境で入れられるようになりました。
- `package.json` に `legacyFolders` を設定しました。  
  これにより、古い UnityPackage 版の BlendMaestro を入れている環境に VCC / ALCOM 等で VPM 版の BlendMaestro を入れた際に、同じツールが複数入ることによる問題を修正します。  
  VCC / ALCOM 等は、`legacyFolders` に指定されている ディレクトリ/フォルダ が存在する場合には、その ディレクトリ/フォルダ を削除してくれます。  
  これにより、古い UnityPackage 版の BlendMaestro が削除されることにより、同じツールが複数入ることを防ぐことができます。  
  詳しくは [英語の公式ドキュメント](https://vcc.docs.vrchat.com/vpm/packages#vpm-manifest-additions) の説明を参照してください。

